### PR TITLE
fix: 修复在记录变更时未正确删除originRecordMap中的条目

### DIFF
--- a/src/views/demoStandardUsage/components/demoStandardUsageTable.vue
+++ b/src/views/demoStandardUsage/components/demoStandardUsageTable.vue
@@ -301,8 +301,8 @@ export default {
         } else if (!deepEqual(currentRecord, originRecord)) {
           result.change.originRecordList.push(originRecord);
           result.change.currentRecordList.push(currentRecord);
-          originRecordMap.delete(currentRecord.id);
         }
+        originRecordMap.delete(currentRecord.id);
       });
 
       // 检查删除


### PR DESCRIPTION
移动originRecordMap.delete操作到条件判断外部，确保无论记录是否变更都会删除对应条目，避免潜在的内存泄漏问题